### PR TITLE
Add support for scraping parental guide page

### DIFF
--- a/cinemagoerng/model.py
+++ b/cinemagoerng/model.py
@@ -113,7 +113,9 @@ class Advisories:
     spoiler_violence: SpoilerAdvisory = field(default_factory=SpoilerAdvisory)
     spoiler_profanity: SpoilerAdvisory = field(default_factory=SpoilerAdvisory)
     spoiler_alcohol: SpoilerAdvisory = field(default_factory=SpoilerAdvisory)
-    spoiler_frightening: SpoilerAdvisory = field(default_factory=SpoilerAdvisory)
+    spoiler_frightening: SpoilerAdvisory = field(
+        default_factory=SpoilerAdvisory
+    )
 
 
 @dataclass(kw_only=True)
@@ -130,7 +132,7 @@ class _Title:
     plot: dict[str, str] = field(default_factory=dict)
     plot_summaries: list[dict[str, str]] = field(default_factory=list)
     taglines: list[str] = field(default_factory=list)
-    akas: list[Aka] = field(default_factory=list)
+    akas: list[AKA] = field(default_factory=list)
     certification: Certification | None = None
     advisories: Advisories | None = None
 
@@ -272,7 +274,16 @@ class TVSpecial(_TimedTitle):
     type_id: Literal["tvSpecial"] = "tvSpecial"
 
 
-Title: TypeAlias = Movie | TVMovie | ShortMovie | TVShortMovie \
-                 | VideoMovie | MusicVideo | VideoGame \
-                 | TVSeries | TVMiniSeries | TVEpisode \
-                 | TVSpecial  # noqa: E126
+Title: TypeAlias = (
+    Movie
+    | TVMovie
+    | ShortMovie
+    | TVShortMovie
+    | VideoMovie
+    | MusicVideo
+    | VideoGame
+    | TVSeries
+    | TVMiniSeries
+    | TVEpisode
+    | TVSpecial
+)  # noqa: E126

--- a/cinemagoerng/model.py
+++ b/cinemagoerng/model.py
@@ -69,6 +69,53 @@ class AKA:
         return len(self.notes) > 0
 
 
+@dataclass
+class Certificate:
+    country: str
+    certificate: str
+    attribute: str | None = None
+
+
+@dataclass
+class Certification:
+    mpaa: str | None = None
+    certificates: list[Certificate] = field(default_factory=list)
+
+
+@dataclass
+class Votes:
+    none: int = 0
+    mild: int = 0
+    moderate: int = 0
+    severe: int = 0
+
+
+@dataclass
+class Advisory:
+    details: list[str] = field(default_factory=list)
+    status: Literal["None", "Mild", "Moderate", "Severe"] = "None"
+    votes: Votes = field(default_factory=Votes)
+
+
+@dataclass
+class SpoilerAdvisory:
+    details: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Advisories:
+    nudity: Advisory = field(default_factory=Advisory)
+    violence: Advisory = field(default_factory=Advisory)
+    profanity: Advisory = field(default_factory=Advisory)
+    alcohol: Advisory = field(default_factory=Advisory)
+    frightening: Advisory = field(default_factory=Advisory)
+    spoiler_nudity: SpoilerAdvisory = field(default_factory=SpoilerAdvisory)
+    spoiler_violence: SpoilerAdvisory = field(default_factory=SpoilerAdvisory)
+    spoiler_profanity: SpoilerAdvisory = field(default_factory=SpoilerAdvisory)
+    spoiler_alcohol: SpoilerAdvisory = field(default_factory=SpoilerAdvisory)
+    spoiler_frightening: SpoilerAdvisory = field(default_factory=SpoilerAdvisory)
+
+
 @dataclass(kw_only=True)
 class _Title:
     imdb_id: str
@@ -83,7 +130,9 @@ class _Title:
     plot: dict[str, str] = field(default_factory=dict)
     plot_summaries: list[dict[str, str]] = field(default_factory=list)
     taglines: list[str] = field(default_factory=list)
-    akas: list[AKA] = field(default_factory=list)
+    akas: list[Aka] = field(default_factory=list)
+    certification: Certification | None = None
+    advisories: Advisories | None = None
 
     rating: Decimal | None = None
     vote_count: int = 0

--- a/cinemagoerng/model.py
+++ b/cinemagoerng/model.py
@@ -83,7 +83,7 @@ class Certification:
 
 
 @dataclass
-class Votes:
+class AdvisoryVotes:
     none: int = 0
     mild: int = 0
     moderate: int = 0
@@ -94,7 +94,7 @@ class Votes:
 class Advisory:
     details: list[str] = field(default_factory=list)
     status: Literal["None", "Mild", "Moderate", "Severe"] = "None"
-    votes: Votes = field(default_factory=Votes)
+    votes: AdvisoryVotes = field(default_factory=AdvisoryVotes)
 
 
 @dataclass

--- a/cinemagoerng/piculet.py
+++ b/cinemagoerng/piculet.py
@@ -186,6 +186,7 @@ class TreeRule:
     key: str | TreePicker
     extractor: TreePicker | TreeCollector
     foreach: TreePath | None = None
+    transforms: list[Transform] = field(default_factory=list)
 
 
 @dataclass(kw_only=True)
@@ -193,6 +194,7 @@ class MapRule:
     key: str | MapPicker
     extractor: MapPicker | MapCollector
     foreach: MapPath | None = None
+    transforms: list[Transform] = field(default_factory=list)
 
 
 def extract(root: TreeNode | MapNode, rule: TreeRule | MapRule) -> MapNode:
@@ -222,6 +224,9 @@ def extract(root: TreeNode | MapNode, rule: TreeRule | MapRule) -> MapNode:
                     value = transform.apply(value)
                 values.append(value)
         value = values[0] if rule.extractor.foreach is None else values
+
+        for transform in rule.transforms:
+            value = transform.apply(value)
 
         match rule.key:
             case str():

--- a/cinemagoerng/registry.py
+++ b/cinemagoerng/registry.py
@@ -16,7 +16,7 @@
 import html
 import json
 import re
-from typing import TypedDict
+from typing import TypedDict, Any
 
 from .piculet import (
     MapNode,
@@ -77,20 +77,11 @@ def set_plot_langs(data):
             episode["plot"] = {data["_page_lang"]: episode["_plot"]}
 
 
-def dict_from_list(data, value):
-    """
-    Convert a list of dictionaries to a single dictionary.
-    """
-    key = list(data.keys())[0]
-    data[key] = {k: v for d in data[key] for k, v in d.items()}
-
-
 def update_postprocessors(registry: dict[str, Postprocessor]) -> None:
     registry.update({
         "unpack_dicts": unpack_dicts,
         "generate_episode_map": generate_episode_map,
         "set_plot_langs": set_plot_langs,
-        "dict_from_list": dict_from_list,
     })
 
 
@@ -235,6 +226,13 @@ def extract_value(value: dict) -> str:
     return value.get("value")
 
 
+def flatten_list_of_dicts(value: list[dict[str, Any]]) -> dict[str, Any]:
+    """
+    Convert a list of dictionaries to a single dictionary.
+    """
+    return {k: v for d in value for k, v in d.items()}
+
+
 def update_transformers(registry: dict[str, Transformer]) -> None:
     registry.update({
         "date": make_date,
@@ -258,4 +256,5 @@ def update_transformers(registry: dict[str, Transformer]) -> None:
         "episode_number": parse_episode_number,
         "exists": exists,
         "extract_value": extract_value,
+        "flatten_list_of_dicts": flatten_list_of_dicts,
     })

--- a/cinemagoerng/registry.py
+++ b/cinemagoerng/registry.py
@@ -16,7 +16,7 @@
 import html
 import json
 import re
-from typing import TypedDict, Any
+from typing import Any, TypedDict
 
 from .piculet import (
     MapNode,
@@ -25,9 +25,7 @@ from .piculet import (
     Transformer,
     TreeNode,
     TreePath,
-    deserialize,
 )
-from . import model, piculet
 
 
 def parse_next_data(root: TreeNode) -> MapNode:

--- a/cinemagoerng/registry.py
+++ b/cinemagoerng/registry.py
@@ -25,7 +25,9 @@ from .piculet import (
     Transformer,
     TreeNode,
     TreePath,
+    deserialize
 )
+from . import model, piculet
 
 
 def parse_next_data(root: TreeNode) -> MapNode:
@@ -75,11 +77,20 @@ def set_plot_langs(data):
             episode["plot"] = {data["_page_lang"]: episode["_plot"]}
 
 
+def dict_from_list(data, value):
+    """
+    Convert a list of dictionaries to a single dictionary.
+    """
+    key = list(data.keys())[0]
+    data[key] = {k: v for d in data[key] for k, v in d.items()}
+
+
 def update_postprocessors(registry: dict[str, Postprocessor]) -> None:
     registry.update({
         "unpack_dicts": unpack_dicts,
         "generate_episode_map": generate_episode_map,
         "set_plot_langs": set_plot_langs,
+        "dict_from_list": dict_from_list,
     })
 
 
@@ -128,7 +139,8 @@ def parse_type_id(value: str) -> str:
 
 
 def parse_year_range(value: str) -> dict[str, int]:
-    tokens = value.strip().split("-")
+    split_char = "–" if "–" in value else "-"
+    tokens = value.strip().split(split_char)
     data = {"year": int(tokens[0])}
     if (len(tokens) > 1) and len(tokens[1]) > 0:
         data["end_year"] = int(tokens[1])
@@ -215,6 +227,14 @@ def parse_episode_number(value: str) -> str:
     return value.strip().split("Episode ")[1]
 
 
+def exists(value: str) -> bool:
+    return value is not None and value != ''
+
+
+def extract_value(value: dict) -> str:
+    return value.get("value")
+
+
 def update_transformers(registry: dict[str, Transformer]) -> None:
     registry.update({
         "date": make_date,
@@ -236,4 +256,6 @@ def update_transformers(registry: dict[str, Transformer]) -> None:
         "episode_count": parse_episode_count,
         "season_number": parse_season_number,
         "episode_number": parse_episode_number,
+        "exists": exists,
+        "extract_value": extract_value,
     })

--- a/cinemagoerng/registry.py
+++ b/cinemagoerng/registry.py
@@ -25,7 +25,7 @@ from .piculet import (
     Transformer,
     TreeNode,
     TreePath,
-    deserialize
+    deserialize,
 )
 from . import model, piculet
 
@@ -46,10 +46,12 @@ def remove_see_more(root: TreeNode) -> TreeNode:
 
 
 def update_preprocessors(registry: dict[str, Preprocessor]) -> None:
-    registry.update({
-        "parse_next_data": parse_next_data,
-        "remove_see_more": remove_see_more,
-    })
+    registry.update(
+        {
+            "parse_next_data": parse_next_data,
+            "remove_see_more": remove_see_more,
+        }
+    )
 
 
 def unpack_dicts(data):
@@ -78,11 +80,13 @@ def set_plot_langs(data):
 
 
 def update_postprocessors(registry: dict[str, Postprocessor]) -> None:
-    registry.update({
-        "unpack_dicts": unpack_dicts,
-        "generate_episode_map": generate_episode_map,
-        "set_plot_langs": set_plot_langs,
-    })
+    registry.update(
+        {
+            "unpack_dicts": unpack_dicts,
+            "generate_episode_map": generate_episode_map,
+            "set_plot_langs": set_plot_langs,
+        }
+    )
 
 
 class DateDict(TypedDict):
@@ -100,8 +104,20 @@ def make_date(x: DateDict) -> str | None:
     return f"{year}-{month:02}-{day:02}"
 
 
-_month_names = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+_month_names = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+]
 _month_nums = {m: (i + 1) for i, m in enumerate(_month_names)}
 
 
@@ -151,7 +167,7 @@ def parse_runtime(value: str) -> int:
 
 
 def parse_vote_count(value: str) -> int:
-    return int(value[1:-1].replace(",", ""))   # remove parens around value
+    return int(value[1:-1].replace(",", ""))  # remove parens around value
 
 
 def parse_ranking(value: str) -> int:
@@ -219,7 +235,7 @@ def parse_episode_number(value: str) -> str:
 
 
 def exists(value: str) -> bool:
-    return value is not None and value != ''
+    return value is not None and value != ""
 
 
 def extract_value(value: dict) -> str:
@@ -234,27 +250,29 @@ def flatten_list_of_dicts(value: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def update_transformers(registry: dict[str, Transformer]) -> None:
-    registry.update({
-        "date": make_date,
-        "text_date": parse_text_date,
-        "unescape": html.unescape,
-        "div60": lambda x: x // 60,
-        "href_id": parse_href_id,
-        "type_id": parse_type_id,
-        "year_range": parse_year_range,
-        "country_code": parse_country_code,
-        "language_code": parse_language_code,
-        "runtime": parse_runtime,
-        "vote_count": parse_vote_count,
-        "ranking": parse_ranking,
-        "locale": parse_locale,
-        "credit_section_id": parse_credit_section_id,
-        "credit_info": parse_credit_info,
-        "episode_series_title": parse_episode_series_title,
-        "episode_count": parse_episode_count,
-        "season_number": parse_season_number,
-        "episode_number": parse_episode_number,
-        "exists": exists,
-        "extract_value": extract_value,
-        "flatten_list_of_dicts": flatten_list_of_dicts,
-    })
+    registry.update(
+        {
+            "date": make_date,
+            "text_date": parse_text_date,
+            "unescape": html.unescape,
+            "div60": lambda x: x // 60,
+            "href_id": parse_href_id,
+            "type_id": parse_type_id,
+            "year_range": parse_year_range,
+            "country_code": parse_country_code,
+            "language_code": parse_language_code,
+            "runtime": parse_runtime,
+            "vote_count": parse_vote_count,
+            "ranking": parse_ranking,
+            "locale": parse_locale,
+            "credit_section_id": parse_credit_section_id,
+            "credit_info": parse_credit_info,
+            "episode_series_title": parse_episode_series_title,
+            "episode_count": parse_episode_count,
+            "season_number": parse_season_number,
+            "episode_number": parse_episode_number,
+            "exists": exists,
+            "extract_value": extract_value,
+            "flatten_list_of_dicts": flatten_list_of_dicts,
+        }
+    )

--- a/cinemagoerng/specs/title_parental_guide.json
+++ b/cinemagoerng/specs/title_parental_guide.json
@@ -11,26 +11,32 @@
 	  }
 	},
 	{
-      "key": "type_id",
-      "extractor": {
-        "path": "normalize-space(//div[@div='quicklinks']//span[@class='nobr']/text())",
-        "transforms": ["type_id"]
-      }
-    },
-    {
-      "key": "title",
-      "extractor": {
-        "path": "//h3[@itemprop='name']/a/text()",
-        "transforms": ["strip"]
-      }
-    },
+	  "key": "type_id",
+	  "extractor": {
+		"path": "normalize-space(//div[@div='quicklinks']//span[@class='nobr']/text())",
+		"transforms": [
+		  "type_id"
+		]
+	  }
+	},
 	{
-      "key": "__dict__",
-      "extractor": {
-        "path": "translate(normalize-space(//h3[@itemprop='name']//span/text()), '()', '')",
-        "transforms": ["year_range"]
-      }
-    },
+	  "key": "title",
+	  "extractor": {
+		"path": "//h3[@itemprop='name']/a/text()",
+		"transforms": [
+		  "strip"
+		]
+	  }
+	},
+	{
+	  "key": "__dict__",
+	  "extractor": {
+		"path": "translate(normalize-space(//h3[@itemprop='name']//span/text()), '()', '')",
+		"transforms": [
+		  "year_range"
+		]
+	  }
+	},
 	{
 	  "key": "certification",
 	  "extractor": {
@@ -62,7 +68,9 @@
 				  "key": "attribute",
 				  "extractor": {
 					"path": "substring-after(.//text()[2], ' ')",
-					"transforms": ["strip"]
+					"transforms": [
+					  "strip"
+					]
 				  }
 				}
 			  ]
@@ -73,10 +81,14 @@
 	},
 	{
 	  "key": "advisories",
-	  "transforms": ["flatten_list_of_dicts"],
+	  "transforms": [
+		"flatten_list_of_dicts"
+	  ],
 	  "extractor": {
 		"foreach": "//section[starts-with(@id, 'advisory-')]",
-		"transforms": ["make_dict"],
+		"transforms": [
+		  "make_dict"
+		],
 		"rules": [
 		  {
 			"key": "key",
@@ -92,7 +104,9 @@
 				  "key": "details",
 				  "extractor": {
 					"foreach": ".//li[@class='ipl-zebra-list__item']",
-					"transforms": ["extract_value"],
+					"transforms": [
+					  "extract_value"
+					],
 					"rules": [
 					  {
 						"key": "value",
@@ -111,10 +125,14 @@
 				},
 				{
 				  "key": "votes",
-				  "transforms": ["flatten_list_of_dicts"],
+				  "transforms": [
+					"flatten_list_of_dicts"
+				  ],
 				  "extractor": {
 					"foreach": ".//span[@class='ipl-vote-button']",
-					"transforms": ["make_dict"],
+					"transforms": [
+					  "make_dict"
+					],
 					"rules": [
 					  {
 						"key": "key",
@@ -141,5 +159,7 @@
 	  }
 	}
   ],
-  "post": ["unpack_dicts"]
+  "post": [
+	"unpack_dicts"
+  ]
 }

--- a/cinemagoerng/specs/title_parental_guide.json
+++ b/cinemagoerng/specs/title_parental_guide.json
@@ -1,6 +1,8 @@
 {
   "version": "20240518",
   "url": "https://www.imdb.com/title/%(imdb_id)s/parentalguide",
+  "doctype": "html",
+  "path_type": "xpath",
   "rules": [
 	{
 	  "key": "imdb_id",
@@ -12,22 +14,22 @@
       "key": "type_id",
       "extractor": {
         "path": "normalize-space(//div[@div='quicklinks']//span[@class='nobr']/text())",
-        "transform": "type_id"
+        "transforms": ["type_id"]
       }
     },
     {
       "key": "title",
       "extractor": {
         "path": "//h3[@itemprop='name']/a/text()",
-        "transform": "strip"
+        "transforms": ["strip"]
       }
     },
 	{
       "key": "_year",
       "extractor": {
         "path": "translate(normalize-space(//h3[@itemprop='name']//span/text()), '()', '')",
-        "transform": "year_range",
-        "post": "unpack"
+        "transforms": ["year_range"],
+        "post": ["unpack"]
       }
     },
 	{
@@ -61,7 +63,7 @@
 				  "key": "attribute",
 				  "extractor": {
 					"path": "substring-after(.//text()[2], ' ')",
-					"transform": "strip"
+					"transforms": ["strip"]
 				  }
 				}
 			  ]
@@ -74,8 +76,8 @@
 	  "key": "advisories",
 	  "extractor": {
 		"foreach": "//section[starts-with(@id, 'advisory-')]",
-		"transform": "make_dict",
-		"post": "dict_from_list",
+		"transforms": ["make_dict"],
+		"post": ["dict_from_list"],
 		"rules": [
 		  {
 			"key": "key",
@@ -91,7 +93,7 @@
 				  "key": "details",
 				  "extractor": {
 					"foreach": ".//li[@class='ipl-zebra-list__item']",
-					"transform": "extract_value",
+					"transforms": ["extract_value"],
 					"rules": [
 					  {
 						"key": "value",
@@ -112,8 +114,8 @@
 				  "key": "votes",
 				  "extractor": {
 					"foreach": ".//span[@class='ipl-vote-button']",
-					"transform": "make_dict",
-					"post": "dict_from_list",
+					"transforms": ["make_dict"],
+					"post": ["dict_from_list"],
 					"rules": [
 					  {
 						"key": "key",
@@ -125,7 +127,7 @@
 						"key": "value",
 						"extractor": {
 						  "path": ".//span/text()",
-						  "transform": "int"
+						  "transforms": ["int"]
 						}
 					  }
 					]

--- a/cinemagoerng/specs/title_parental_guide.json
+++ b/cinemagoerng/specs/title_parental_guide.json
@@ -1,0 +1,141 @@
+{
+  "version": "20240518",
+  "url": "https://www.imdb.com/title/%(imdb_id)s/parentalguide",
+  "rules": [
+	{
+	  "key": "imdb_id",
+	  "extractor": {
+		"path": "//meta[@property='pageId']/@content"
+	  }
+	},
+	{
+      "key": "type_id",
+      "extractor": {
+        "path": "normalize-space(//div[@div='quicklinks']//span[@class='nobr']/text())",
+        "transform": "type_id"
+      }
+    },
+    {
+      "key": "title",
+      "extractor": {
+        "path": "//h3[@itemprop='name']/a/text()",
+        "transform": "strip"
+      }
+    },
+	{
+      "key": "_year",
+      "extractor": {
+        "path": "translate(normalize-space(//h3[@itemprop='name']//span/text()), '()', '')",
+        "transform": "year_range",
+        "post": "unpack"
+      }
+    },
+	{
+	  "key": "certification",
+	  "extractor": {
+		"rules": [
+		  {
+			"key": "mpaa",
+			"extractor": {
+			  "path": "//tr[@id='mpaa-rating']/td[2]//text()"
+			}
+		  },
+		  {
+			"key": "certificates",
+			"extractor": {
+			  "foreach": "//tr[@id='certifications-list']//li",
+			  "rules": [
+				{
+				  "key": "country",
+				  "extractor": {
+					"path": "substring-before(.//a/text(), ':')"
+				  }
+				},
+				{
+				  "key": "certificate",
+				  "extractor": {
+					"path": "substring-after(.//a/text(), ':')"
+				  }
+				},
+				{
+				  "key": "attribute",
+				  "extractor": {
+					"path": "substring-after(.//text()[2], ' ')",
+					"transform": "strip"
+				  }
+				}
+			  ]
+			}
+		  }
+		]
+	  }
+	},
+	{
+	  "key": "advisories",
+	  "extractor": {
+		"foreach": "//section[starts-with(@id, 'advisory-')]",
+		"transform": "make_dict",
+		"post": "dict_from_list",
+		"rules": [
+		  {
+			"key": "key",
+			"extractor": {
+			  "path": "translate(substring-after(./@id, 'advisory-'), '-', '_')"
+			}
+		  },
+		  {
+			"key": "value",
+			"extractor": {
+			  "rules": [
+				{
+				  "key": "details",
+				  "extractor": {
+					"foreach": ".//li[@class='ipl-zebra-list__item']",
+					"transform": "extract_value",
+					"rules": [
+					  {
+						"key": "value",
+						"extractor": {
+						  "path": "normalize-space(.//text())"
+						}
+					  }
+					]
+				  }
+				},
+				{
+				  "key": "status",
+				  "extractor": {
+					"path": "normalize-space(.//span[contains(@class, 'ipl-status-pill')]/text())"
+				  }
+				},
+				{
+				  "key": "votes",
+				  "extractor": {
+					"foreach": ".//span[@class='ipl-vote-button']",
+					"transform": "make_dict",
+					"post": "dict_from_list",
+					"rules": [
+					  {
+						"key": "key",
+						"extractor": {
+						  "path": "./button/@value"
+						}
+					  },
+					  {
+						"key": "value",
+						"extractor": {
+						  "path": ".//span/text()",
+						  "transform": "int"
+						}
+					  }
+					]
+				  }
+				}
+			  ]
+			}
+		  }
+		]
+	  }
+	}
+  ]
+}

--- a/cinemagoerng/specs/title_parental_guide.json
+++ b/cinemagoerng/specs/title_parental_guide.json
@@ -1,5 +1,5 @@
 {
-  "version": "20240518",
+  "version": "20240702",
   "url": "https://www.imdb.com/title/%(imdb_id)s/parentalguide",
   "doctype": "html",
   "path_type": "xpath",
@@ -25,11 +25,10 @@
       }
     },
 	{
-      "key": "_year",
+      "key": "__dict__",
       "extractor": {
         "path": "translate(normalize-space(//h3[@itemprop='name']//span/text()), '()', '')",
-        "transforms": ["year_range"],
-        "post": ["unpack"]
+        "transforms": ["year_range"]
       }
     },
 	{
@@ -74,10 +73,10 @@
 	},
 	{
 	  "key": "advisories",
+	  "transforms": ["flatten_list_of_dicts"],
 	  "extractor": {
 		"foreach": "//section[starts-with(@id, 'advisory-')]",
 		"transforms": ["make_dict"],
-		"post": ["dict_from_list"],
 		"rules": [
 		  {
 			"key": "key",
@@ -112,10 +111,10 @@
 				},
 				{
 				  "key": "votes",
+				  "transforms": ["flatten_list_of_dicts"],
 				  "extractor": {
 					"foreach": ".//span[@class='ipl-vote-button']",
 					"transforms": ["make_dict"],
-					"post": ["dict_from_list"],
 					"rules": [
 					  {
 						"key": "key",
@@ -139,5 +138,6 @@
 		]
 	  }
 	}
-  ]
+  ],
+  "post": ["unpack_dicts"]
 }

--- a/cinemagoerng/specs/title_parental_guide.json
+++ b/cinemagoerng/specs/title_parental_guide.json
@@ -1,5 +1,5 @@
 {
-  "version": "20240702",
+  "version": "20240704",
   "url": "https://www.imdb.com/title/%(imdb_id)s/parentalguide",
   "doctype": "html",
   "path_type": "xpath",
@@ -125,8 +125,10 @@
 					  {
 						"key": "value",
 						"extractor": {
-						  "path": ".//span/text()",
-						  "transforms": ["int"]
+						  "path": "translate(.//span/text(), ',', '')",
+						  "transforms": [
+							"int"
+						  ]
 						}
 					  }
 					]

--- a/cinemagoerng/web.py
+++ b/cinemagoerng/web.py
@@ -53,9 +53,8 @@ def _spec(page: str, /) -> piculet.Spec:
     return piculet.load_spec(json.loads(content))
 
 
-TitlePage: TypeAlias = Literal["main", "reference", "taglines", "episodes"]
-TitleUpdatePage: TypeAlias = Literal["main", "reference", "taglines",
-                                     "episodes", "akas"]
+TitlePage: TypeAlias = Literal["main", "reference", "taglines", "episodes", "parental_guide"]
+TitleUpdatePage: TypeAlias = Literal["main", "reference", "taglines", "episodes", "akas", "parental_guide"]
 
 
 def get_title(imdb_id: str, *, page: TitlePage = "reference",
@@ -90,5 +89,11 @@ def update_title(title: model.Title, /, *, page: TitleUpdatePage,
         elif key == "akas":
             value = [piculet.deserialize(aka, model.AKA) for aka in value]
             title.akas.extend(value)
+        elif key == "certification":
+            value = piculet.deserialize(value, model.Certification)
+            setattr(title, key, value)
+        elif key == "advisories":
+            value = piculet.deserialize(value, model.Advisories)
+            setattr(title, key, value)
         else:
             setattr(title, key, value)

--- a/cinemagoerng/web.py
+++ b/cinemagoerng/web.py
@@ -53,12 +53,17 @@ def _spec(page: str, /) -> piculet.Spec:
     return piculet.load_spec(json.loads(content))
 
 
-TitlePage: TypeAlias = Literal["main", "reference", "taglines", "episodes", "parental_guide"]
-TitleUpdatePage: TypeAlias = Literal["main", "reference", "taglines", "episodes", "akas", "parental_guide"]
+TitlePage: TypeAlias = Literal[
+    "main", "reference", "taglines", "episodes", "parental_guide"
+]
+TitleUpdatePage: TypeAlias = Literal[
+    "main", "reference", "taglines", "episodes", "akas", "parental_guide"
+]
 
 
-def get_title(imdb_id: str, *, page: TitlePage = "reference",
-              **kwargs) -> model.Title | None:
+def get_title(
+    imdb_id: str, *, page: TitlePage = "reference", **kwargs
+) -> model.Title | None:
     spec = _spec(f"title_{page}")
     url = spec.url % ({"imdb_id": imdb_id} | kwargs)
     try:
@@ -67,18 +72,29 @@ def get_title(imdb_id: str, *, page: TitlePage = "reference",
         if e.status == HTTPStatus.NOT_FOUND:
             return None
         raise e  # pragma: no cover
-    data = piculet.scrape(document, doctype=spec.doctype, rules=spec.rules,
-                          pre=spec.pre, post=spec.post)
+    data = piculet.scrape(
+        document,
+        doctype=spec.doctype,
+        rules=spec.rules,
+        pre=spec.pre,
+        post=spec.post,
+    )
     return piculet.deserialize(data, model.Title)
 
 
-def update_title(title: model.Title, /, *, page: TitleUpdatePage,
-                 keys: list[str], **kwargs) -> None:
+def update_title(
+    title: model.Title, /, *, page: TitleUpdatePage, keys: list[str], **kwargs
+) -> None:
     spec = _spec(f"title_{page}")
     url = spec.url % ({"imdb_id": title.imdb_id} | kwargs)
     document = fetch(url, key=f"title_{title.imdb_id}_{page}.{spec.doctype}")
-    data = piculet.scrape(document, doctype=spec.doctype, rules=spec.rules,
-                          pre=spec.pre, post=spec.post)
+    data = piculet.scrape(
+        document,
+        doctype=spec.doctype,
+        rules=spec.rules,
+        pre=spec.pre,
+        post=spec.post,
+    )
     for key in keys:
         value = data.get(key)
         if value is None:

--- a/tests/test_parentalguide.py
+++ b/tests/test_parentalguide.py
@@ -1,0 +1,33 @@
+import pytest
+
+from cinemagoerng import web
+
+
+@pytest.mark.parametrize(("imdb_id", "nudity_status", "mpaa_rating"), [
+    (
+            "tt0133093",  # The Matrix
+            "Mild",
+            "Rated R for sci-fi violence and brief language",
+    ),
+])
+def test_title_parser_should_set_parentalguide(imdb_id, nudity_status, mpaa_rating):
+    parsed = web.get_title(imdb_id=imdb_id, page="parental_guide")
+
+    assert parsed.advisories.nudity.status == nudity_status
+    assert parsed.certification.mpaa == mpaa_rating
+
+
+@pytest.mark.parametrize(("imdb_id", "nudity_status", "certificate"), [
+    (
+            "tt0436992",  # The Matrix
+            "None",
+            "TV-PG",
+    ),
+])
+def test_title_update_certificate(imdb_id, nudity_status, certificate):
+    parsed = web.get_title(imdb_id=imdb_id)
+    web.update_title(parsed, page="parental_guide", keys=["certification", "advisories"])
+
+    assert parsed.advisories.nudity.status == nudity_status
+    us_certificates = [certificate for certificate in parsed.certification.certificates if certificate.country == "United States"]
+    assert us_certificates[0].certificate == certificate

--- a/tests/test_parentalguide.py
+++ b/tests/test_parentalguide.py
@@ -8,8 +8,14 @@ from cinemagoerng import web
             "tt0133093",  # The Matrix
             "Mild",
             "Rated R for sci-fi violence and brief language",
-    ),
-])
+        ),
+        (
+            "tt0468569",  # The Dark Knight
+            "None",
+            "Rated PG-13 for intense sequences of violence and some menace",
+        ),
+    ],
+)
 def test_title_parser_should_set_parentalguide(imdb_id, nudity_status, mpaa_rating):
     parsed = web.get_title(imdb_id=imdb_id, page="parental_guide")
 
@@ -17,17 +23,27 @@ def test_title_parser_should_set_parentalguide(imdb_id, nudity_status, mpaa_rati
     assert parsed.certification.mpaa == mpaa_rating
 
 
-@pytest.mark.parametrize(("imdb_id", "nudity_status", "certificate"), [
-    (
+@pytest.mark.parametrize(
+    ("imdb_id", "nudity_status", "certificate_data"),
+    [
+        (
             "tt0436992",  # The Matrix
             "None",
-            "TV-PG",
-    ),
-])
-def test_title_update_certificate(imdb_id, nudity_status, certificate):
+            ["United States", "TV-PG"],
+        ),
+        (
+            "tt0903747",  # Breaking Bad
+            "Moderate",
+            ["Argentina", "18"],
+        ),
+    ],
+)
+def test_title_update_certificate(imdb_id, nudity_status, certificate_data):
     parsed = web.get_title(imdb_id=imdb_id)
     web.update_title(parsed, page="parental_guide", keys=["certification", "advisories"])
 
     assert parsed.advisories.nudity.status == nudity_status
-    us_certificates = [certificate for certificate in parsed.certification.certificates if certificate.country == "United States"]
-    assert us_certificates[0].certificate == certificate
+    specific_certificates = [
+        certificate for certificate in parsed.certification.certificates if certificate.country == certificate_data[0]
+    ]
+    assert specific_certificates[0].certificate == certificate_data[1]


### PR DESCRIPTION
This pull request adds support for scraping the parental guide page. It includes changes to the code that allow parsing and updating the certification and advisories of a title. The changes also include new data classes for Certification, Certificate, Advisories, Advisory, SpoilerAdvisory, and Votes. These changes enable the extraction and storage of information related to parental guidance for titles.