### PR TITLE
Fix KeyError if fetching episodes without plot summary

### DIFF
--- a/src/cinemagoerng/registry.py
+++ b/src/cinemagoerng/registry.py
@@ -64,7 +64,11 @@ def set_episodes_plot_languages(data: CollectedData) -> CollectedData:
     lang = data.get("_page_lang")
     if lang is not None:
         for episode in data.get("episodes", []):
-            episode["plot"] = {lang: episode["plot"]}
+            plot = episode.get("plot")
+            if plot is not None:
+                episode["plot"] = {lang: plot}
+            else:
+                episode["plot"] = {}
     return data
 
 


### PR DESCRIPTION
Fix for [this issue](https://github.com/cinemagoer/cinemagoerng/issues/17) when occurs when calling set_episodes on a series and season which has episodes without a plot summary. If there is not a plot summary, the key 'plot' is not created when the scraped data is parsed, and so the KeyError occurs when it is assumed while adding the language information that it does exist.  